### PR TITLE
Remove camera-reset from Nao image

### DIFF
--- a/recipes-hulks/hulk/hulk.bb
+++ b/recipes-hulks/hulk/hulk.bb
@@ -3,7 +3,6 @@ HOMEPAGE = "https://hulks.de"
 LICENSE = "CLOSED"
 
 SRC_URI = " \
-            file://camera-reset \
             file://hulk.service \
             file://hulk-gdbserver.service \
             file://launchHULK \
@@ -17,7 +16,6 @@ inherit systemd
 
 do_install() {
   install -d ${D}${bindir}
-  install -m 755 ${WORKDIR}/camera-reset ${D}${bindir}
   install -m 755 ${WORKDIR}/launchHULK ${D}${bindir}
   install -m 755 ${WORKDIR}/hulk ${D}${bindir}
 

--- a/recipes-hulks/hulk/hulk/camera-reset
+++ b/recipes-hulks/hulk/hulk/camera-reset
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-/opt/aldebaran/bin/reset-cameras toggle
-echo "Camera reset!"
-sleep 3

--- a/recipes-hulks/hulk/hulk/hulk-gdbserver.service
+++ b/recipes-hulks/hulk/hulk/hulk-gdbserver.service
@@ -5,7 +5,6 @@ After=lola.service
 Conflicts=hulk.service
 
 [Service]
-ExecStartPre=/usr/bin/camera-reset
 ExecStart=/usr/bin/gdbserver 0.0.0.0:1337 /home/nao/bin/hulk
 StandardOutput=journal
 Type=simple

--- a/recipes-hulks/hulk/hulk/hulk.service
+++ b/recipes-hulks/hulk/hulk/hulk.service
@@ -4,7 +4,6 @@ Requires=lola.service
 After=lola.service
 
 [Service]
-ExecStartPre=/usr/bin/camera-reset
 ExecStart=/usr/bin/launchHULK
 StandardOutput=journal
 Type=simple


### PR DESCRIPTION
Removes the camera-reset script from the Nao image. This requires a camera reset from the executable.

Should be merged after HULKs/nao#3823