### PR TITLE
Fix aliveness not starting when network-online times out

### DIFF
--- a/conf/distro/HULKs-OS.conf
+++ b/conf/distro/HULKs-OS.conf
@@ -2,4 +2,4 @@ require conf/distro/nao-core-minimal.conf
 
 DISTRO = "HULKs-OS"
 DISTRO_NAME = "HULKs-OS"
-DISTRO_VERSION = "5.7.3"
+DISTRO_VERSION = "5.7.4"

--- a/recipes-hulks/aliveness/aliveness.bb
+++ b/recipes-hulks/aliveness/aliveness.bb
@@ -11,12 +11,14 @@ S = "${WORKDIR}/git/tools/aliveness"
 
 SYSTEMD_SERVICE:${PN} = "aliveness.service"
 SRC_URI += "file://aliveness.service"
+SRC_URI += "file://enp4s0-wait-online.service"
 
 inherit systemd
 
 do_install:append () {
   install -d "${D}${systemd_unitdir}/system"
   install -m 0644 "${WORKDIR}/aliveness.service" "${D}${systemd_unitdir}/system/"
+  install -m 0644 "${WORKDIR}/enp4s0-wait-online.service" "${D}${systemd_unitdir}/system/"
 }
 
 include aliveness-crates.bb

--- a/recipes-hulks/aliveness/aliveness.bb
+++ b/recipes-hulks/aliveness/aliveness.bb
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/HULKs/hulk.git;branch=main;protocol=https"
 SRCREV = "233c15cdb4f58be01f5b31f789b0ca3bbe613c89"
 S = "${WORKDIR}/git/tools/aliveness"
 
-SYSTEMD_SERVICE:${PN} = "aliveness.service"
+SYSTEMD_SERVICE:${PN} = "aliveness.service enp4s0-wait-online.service"
 SRC_URI += "file://aliveness.service"
 SRC_URI += "file://enp4s0-wait-online.service"
 

--- a/recipes-hulks/aliveness/aliveness/aliveness.service
+++ b/recipes-hulks/aliveness/aliveness/aliveness.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Aliveness Service
-Requires=dbus.socket systemd-networkd-wait-online@enp4s0.service
-After=dbus.socket systemd-networkd-wait-online@enp4s0.service
+Requires=dbus.socket enp4s0-wait-online.service
+After=dbus.socket enp4s0-wait-online.service
 
 [Service]
 ExecStart=/usr/bin/aliveness-service

--- a/recipes-hulks/aliveness/aliveness/enp4s0-wait-online.service
+++ b/recipes-hulks/aliveness/aliveness/enp4s0-wait-online.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Wait for Network Interface enp4s0 to be Configured
+Documentation=man:systemd-networkd-wait-online.service(8)
+DefaultDependencies=no
+Conflicts=shutdown.target
+Requires=systemd-networkd.service
+After=systemd-networkd.service
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i enp4s0 --timeout=0
+RemainAfterExit=yes


### PR DESCRIPTION
This PR creates a new enp4s0-wait-online service wich waits for enp4s0 to be configured without a timeout.

Fixes HULKs/hulk#265.
